### PR TITLE
テストの最終問題合格後の処理を追加

### DIFF
--- a/app/lessons/easy/async/test/page.tsx
+++ b/app/lessons/easy/async/test/page.tsx
@@ -13,5 +13,8 @@ export default function AsyncTestPage() {
     setTestNum(0);
   }, []);
 
+  const currentLesson = 'Async';
+  const nextLesson = 'Setup&Teardown';
+
   return <TestPage test={test} setJudge={setJudge} setTestNum={setTestNum} judge={judge} testNum={testNum} />;
 }

--- a/app/lessons/easy/matcher/test/page.tsx
+++ b/app/lessons/easy/matcher/test/page.tsx
@@ -13,5 +13,8 @@ export default function MatcherTestPage() {
     setTestNum(0);
   }, []);
 
+  const currentLesson = 'Matcher';
+  const nextLesson = 'Async';
+
   return <TestPage test={test} setJudge={setJudge} setTestNum={setTestNum} judge={judge} testNum={testNum} />;
 }

--- a/lib/lesson-clear-modal.tsx
+++ b/lib/lesson-clear-modal.tsx
@@ -1,0 +1,37 @@
+'use client';
+import Link from 'next/link';
+import {easyLessonLists} from './modal-contents';
+import {usePathname} from 'next/navigation';
+
+export const LessonClearModal = () => {
+  // 初級編のリストと現在表示しているページを取得
+  const easyLessons = easyLessonLists;
+  const pathName = usePathname();
+  // 現在のpathから/testを除く
+  const currentLink = pathName.match(/^\/lessons\/easy\/[^/]+/)?.toString();
+  // 初級編リストから現在のpathと一致するもののタイトルを取得する
+  const current = easyLessons.map((lesson) => {
+    if (lesson.link === currentLink) {
+      return lesson.title;
+    }
+  });
+
+  // 次のレッスンのインデックス番号を取得
+  const nextIndex = easyLessons.findIndex((lesson) => lesson.link === currentLink) + 1;
+  const nextLessonTitle = easyLessons[nextIndex].title;
+  const nextLessonLink = easyLessons[nextIndex].link;
+
+  return (
+    <div className="text-neutral font-bold">
+      <p className="text-lg">
+        {current}合格🎉
+        <br />
+        おめでとうございます✨
+      </p>
+      <p className="mt-5 text-lg md:mt-10">次に進む</p>
+      <Link href={nextLessonLink} className="underline ml-3">
+        {nextLessonTitle}
+      </Link>
+    </div>
+  );
+};

--- a/lib/test-page-format.tsx
+++ b/lib/test-page-format.tsx
@@ -4,6 +4,9 @@ import {judgment} from '@/lib/judgment';
 import {useEffect, useState} from 'react';
 import {Question} from './question-format';
 import {Step} from '@/app/components/ui/step';
+import {openModal} from './lesson-summary-modal';
+import {Modal} from '@/app/components/ui/modal';
+import {LessonClearModal} from './lesson-clear-modal';
 
 type PropsCode = {
   code: string;
@@ -45,7 +48,8 @@ export const TestPage = ({test, setJudge, setTestNum, judge, testNum}: Props) =>
       if (testNum < test.length - 1 && judge === true) {
         setTestNum(testNum + 1);
       } else if (testNum === test.length - 1 && judge === true) {
-        // TODO:モーダルを開く処理
+        // 最後の問題終了時モーダルを開く
+        openModal();
       }
     };
 
@@ -84,6 +88,7 @@ export const TestPage = ({test, setJudge, setTestNum, judge, testNum}: Props) =>
       <div className="flex justify-center mt-5 md:mt-8">
         <Step length={test.length} target={testNum} />
       </div>
+      <Modal modalContent={LessonClearModal()} />
     </div>
   );
 };


### PR DESCRIPTION
テストの最終問題合格＞次へボタン押下後にモーダルが開くように処理を追加。
モーダルのリンクから次のLessonに遷移。